### PR TITLE
expand Social Book size && change personal link

### DIFF
--- a/src/features/shared/components/Footer.tsx
+++ b/src/features/shared/components/Footer.tsx
@@ -34,7 +34,7 @@ export default function Footer() {
         <Heart className="w-4 h-4 text-hot-pink" />
         <span>by</span>
         <a
-          href="https://akimzmerli.site"
+          href="https://webdev4life.com"
           target="_blank"
           rel="noopener noreferrer"
           className="underline underline-offset-2 hover:opacity-80"

--- a/src/features/social-book/components/SocialBook.tsx
+++ b/src/features/social-book/components/SocialBook.tsx
@@ -30,7 +30,7 @@ export default function SocialBook() {
             alt="The Social Book"
             width={780}
             height={405}
-            className="object-contain w-[230] h-[169]"
+            className="object-contain w-full max-w-[780px] h-auto"
           />
         </div>
 


### PR DESCRIPTION

  - Fix responsive social book placeholder image sizing issue
  - Update footer links to webdev4life.com

  Changes

  - SocialBook.tsx: Fixed image className from w-[230] h-[169] to w-full max-w-[780px] h-auto for proper responsive behavior. The missing px units were causing deployment issues where small
  fallback sizes were used.
  - Footer.tsx: Updated footer attribution link to point to webdev4life.com

  Test plan

  - Verify social book image displays at correct size on both localhost and deployment
  - Confirm footer links work correctly