### PR TITLE
Simplify mobile gallery

### DIFF
--- a/src/app/gallery/human/page.tsx
+++ b/src/app/gallery/human/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useEffect, useState } from 'react'
-import { getGalleryImages } from '@/features/gallery/services/galleryData'
+import { getHumanImages } from '@/features/gallery/services/galleryData'
 import DesktopGallery from '@/features/gallery/components/DesktopGallery'
 import MobileGallery from '@/features/gallery/components/MobileGallery'
 import { GalleryImage } from '@/types/gallery'
@@ -36,7 +36,7 @@ export default function HumanGalleryPage() {
 
   useEffect(() => {
     const loadImages = async () => {
-      const galleryImages = await getGalleryImages('human')
+      const galleryImages = await getHumanImages()
       setImages(galleryImages)
     }
     loadImages()

--- a/src/app/gallery/human/page.tsx
+++ b/src/app/gallery/human/page.tsx
@@ -1,46 +1,38 @@
 'use client'
 
-import { useEffect, useState, useRef, useCallback } from 'react'
+import { useEffect, useState } from 'react'
 import { getGalleryImages } from '@/features/gallery/services/galleryData'
 import DesktopGallery from '@/features/gallery/components/DesktopGallery'
 import MobileGallery from '@/features/gallery/components/MobileGallery'
 import { GalleryImage } from '@/types/gallery'
-import { useGalleryTracking } from '@/features/gallery/hooks/useGalleryTracking'
 import LoadingSpinner from '@/shared/ui/LoadingSpinner'
 
 export default function HumanGalleryPage() {
   const [images, setImages] = useState<GalleryImage[]>([])
   const [isMobile, setIsMobile] = useState<boolean | null>(null)
-  const timeoutIdRef = useRef<NodeJS.Timeout | null>(null)
   
-  // Track that this gallery has been viewed
-  const { hasViewedBothMainGalleries: _hasViewedBothMainGalleries } = useGalleryTracking('human')
-
-  const checkMobile = useCallback(() => {
-    const width = window.innerWidth
-    setIsMobile(width < 768)
-  }, [])
-
-  const handleResize = useCallback(() => {
-    if (timeoutIdRef.current) {
-      clearTimeout(timeoutIdRef.current)
-    }
-    timeoutIdRef.current = setTimeout(checkMobile, 100)
-  }, [checkMobile])
 
   useEffect(() => {
+    const checkMobile = () => {
+      const width = window.innerWidth
+      setIsMobile(width < 768)
+    }
+
     // Initial check
     checkMobile()
+
+    let timeoutId: NodeJS.Timeout
+    const handleResize = () => {
+      clearTimeout(timeoutId)
+      timeoutId = setTimeout(checkMobile, 100)
+    }
 
     window.addEventListener('resize', handleResize)
     return () => {
       window.removeEventListener('resize', handleResize)
-      if (timeoutIdRef.current) {
-        clearTimeout(timeoutIdRef.current)
-        timeoutIdRef.current = null
-      }
+      clearTimeout(timeoutId)
     }
-  }, [checkMobile, handleResize])
+  }, [])
 
   useEffect(() => {
     const loadImages = async () => {
@@ -60,8 +52,16 @@ export default function HumanGalleryPage() {
   }
 
   return isMobile ? (
-    <MobileGallery images={images} title="Human" galleryType="human" />
+    <MobileGallery 
+      images={images} 
+      title="human" 
+      galleryType="human" 
+    />
   ) : (
-    <DesktopGallery images={images} title="Human" galleryType="human" />
+    <DesktopGallery 
+      images={images} 
+      title="human" 
+      galleryType="human" 
+    />
   )
 }

--- a/src/app/gallery/non-human/page.tsx
+++ b/src/app/gallery/non-human/page.tsx
@@ -1,46 +1,38 @@
 'use client'
 
-import { useEffect, useState, useRef, useCallback } from 'react'
+import { useEffect, useState } from 'react'
 import { getGalleryImages } from '@/features/gallery/services/galleryData'
 import DesktopGallery from '@/features/gallery/components/DesktopGallery'
 import MobileGallery from '@/features/gallery/components/MobileGallery'
 import { GalleryImage } from '@/types/gallery'
-import { useGalleryTracking } from '@/features/gallery/hooks/useGalleryTracking'
 import LoadingSpinner from '@/shared/ui/LoadingSpinner'
 
 export default function NonHumanGalleryPage() {
   const [images, setImages] = useState<GalleryImage[]>([])
   const [isMobile, setIsMobile] = useState<boolean | null>(null)
-  const timeoutIdRef = useRef<NodeJS.Timeout | null>(null)
   
-  // Track that this gallery has been viewed
-  useGalleryTracking('non-human')
-
-  const checkMobile = useCallback(() => {
-    const width = window.innerWidth
-    setIsMobile(width < 768)
-  }, [])
-
-  const handleResize = useCallback(() => {
-    if (timeoutIdRef.current) {
-      clearTimeout(timeoutIdRef.current)
-    }
-    timeoutIdRef.current = setTimeout(checkMobile, 100)
-  }, [checkMobile])
 
   useEffect(() => {
+    const checkMobile = () => {
+      const width = window.innerWidth
+      setIsMobile(width < 768)
+    }
+
     // Initial check
     checkMobile()
+
+    let timeoutId: NodeJS.Timeout
+    const handleResize = () => {
+      clearTimeout(timeoutId)
+      timeoutId = setTimeout(checkMobile, 100)
+    }
 
     window.addEventListener('resize', handleResize)
     return () => {
       window.removeEventListener('resize', handleResize)
-      if (timeoutIdRef.current) {
-        clearTimeout(timeoutIdRef.current)
-        timeoutIdRef.current = null
-      }
+      clearTimeout(timeoutId)
     }
-  }, [checkMobile, handleResize])
+  }, [])
 
   useEffect(() => {
     const loadImages = async () => {
@@ -60,8 +52,16 @@ export default function NonHumanGalleryPage() {
   }
 
   return isMobile ? (
-    <MobileGallery images={images} title="Non Human" galleryType="non-human" />
+    <MobileGallery 
+      images={images} 
+      title="Non Human" 
+      galleryType="non-human" 
+    />
   ) : (
-    <DesktopGallery images={images} title="Non Human" galleryType="non-human" />
+    <DesktopGallery 
+      images={images} 
+      title="Non Human" 
+      galleryType="non-human" 
+    />
   )
 }

--- a/src/app/gallery/non-human/page.tsx
+++ b/src/app/gallery/non-human/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useEffect, useState } from 'react'
-import { getGalleryImages } from '@/features/gallery/services/galleryData'
+import { getNonHumanImages } from '@/features/gallery/services/galleryData'
 import DesktopGallery from '@/features/gallery/components/DesktopGallery'
 import MobileGallery from '@/features/gallery/components/MobileGallery'
 import { GalleryImage } from '@/types/gallery'
@@ -36,7 +36,7 @@ export default function NonHumanGalleryPage() {
 
   useEffect(() => {
     const loadImages = async () => {
-      const galleryImages = await getGalleryImages('non-human')
+      const galleryImages = await getNonHumanImages()
       setImages(galleryImages)
     }
     loadImages()

--- a/src/app/works/page.tsx
+++ b/src/app/works/page.tsx
@@ -1,0 +1,18 @@
+import Header from '@/shared/layout/Header'
+import Footer from '@/shared/layout/Footer'
+import Works from '@/features/home/components/Works'
+import SocialBook from '@/features/social-book/components/SocialBook'
+
+
+export default function WorksPage() {
+  return (
+    <div className="min-h-screen bg-grainy">
+      <Header />
+      <main className="pt-[70px]">
+        <Works />
+        <SocialBook />
+      </main>
+      <Footer />
+    </div>
+  )
+}

--- a/src/features/gallery/components/DesktopGallery.tsx
+++ b/src/features/gallery/components/DesktopGallery.tsx
@@ -110,24 +110,16 @@ const DesktopGallery = ({ images, title, galleryType }: GalleryProps) => {
   const [currentIndex, setCurrentIndex] = useState(0)
   const [uiVisible, setUiVisible] = useState(true)
   const [isTransitioning, setIsTransitioning] = useState(false)
-  // Dynamic alternate links - lightweight using only viewedGalleries  
-  const [staticAlternateLink, setStaticAlternateLink] = useState(
+  // Static alternate links - same as exhibition gallery
+  const staticAlternateLink = 
     galleryType === 'exhibition' 
       ? '/about-exhibition#exhibition'
       : galleryType === 'human' 
         ? '/gallery/non-human' 
         : '/gallery/human'
-  )
 
-  // Only track and update for human/non-human galleries
-  const shouldTrackProgress = galleryType === 'human' || galleryType === 'non-human'
-  const { hasViewedBothMainGalleries } = useGalleryTracking(galleryType)
-
-  useEffect(() => {
-    if (shouldTrackProgress && hasViewedBothMainGalleries()) {
-      setStaticAlternateLink('/socialbook')
-    }
-  }, [shouldTrackProgress, hasViewedBothMainGalleries])
+  // Track gallery viewing for analytics (no dynamic navigation changes)
+  useGalleryTracking(galleryType)
   const [showWelcomeHint, setShowWelcomeHint] = useState(false)
 
   const scrollContainerRef = useRef<HTMLDivElement>(null)

--- a/src/features/gallery/components/GalleryImage.tsx
+++ b/src/features/gallery/components/GalleryImage.tsx
@@ -2,7 +2,7 @@ import { motion } from 'framer-motion'
 import ImageWithLoader from '@/shared/ui/ImageWithLoader'
 import { GalleryImageProps } from '@/types/gallery'
 
-const GalleryImage = ({ image, priority, onLoad }: GalleryImageProps) => {
+const GalleryImage = ({ image, priority, onLoad, sizes }: GalleryImageProps) => {
   return (
     <motion.div
       initial={{ opacity: 0 }}
@@ -10,7 +10,7 @@ const GalleryImage = ({ image, priority, onLoad }: GalleryImageProps) => {
       exit={{ opacity: 0 }}
       className="w-full h-full relative"
     >
-      <ImageWithLoader image={image} priority={priority} onLoad={onLoad} />
+      <ImageWithLoader image={image} priority={priority} onLoad={onLoad} sizes={sizes} />
     </motion.div>
   )
 }

--- a/src/features/gallery/components/MasonryGallery.tsx
+++ b/src/features/gallery/components/MasonryGallery.tsx
@@ -64,21 +64,19 @@ const MasonryGallery = ({
           </h2>
 
           <Link
-            href={alternateGalleryLink || `/gallery/${type === 'human' ? 'non-human' : 'human'}`}
+            href={type === 'exhibition' ? (alternateGalleryLink || '/about-exhibition#exhibition') : '/#works'}
             onClick={createSmoothLink(
-              alternateGalleryLink || `/gallery/${type === 'human' ? 'non-human' : 'human'}`,
+              type === 'exhibition' ? (alternateGalleryLink || '/about-exhibition#exhibition') : '/#works',
             )}
             className="group inline-flex items-center px-4 py-2 text-hot-pink hover:text-white-rose hover:scale-105 active:scale-95 transition-all duration-300 ease-out text-sm font-light tracking-wider uppercase whitespace-nowrap"
           >
             <span className="flex items-center gap-1">
-              {alternateGalleryLink?.includes('#exhibition') ? (
+              {type === 'exhibition' ? (
                 <>
                   Go Back <> ↗ </>
                 </>
-              ) : alternateGalleryLink?.includes('socialbook') ? (
-                'Social Book ↗'
               ) : (
-                `view ${alternateTitle.toLowerCase()} ↗`
+                'Go Back ↗'
               )}
             </span>
           </Link>

--- a/src/features/gallery/components/MasonryGallery.tsx
+++ b/src/features/gallery/components/MasonryGallery.tsx
@@ -64,9 +64,15 @@ const MasonryGallery = ({
           </h2>
 
           <Link
-            href={type === 'exhibition' ? (alternateGalleryLink || '/about-exhibition#exhibition') : '/#works'}
+            href={
+              type === 'exhibition'
+                ? alternateGalleryLink || '/about-exhibition#exhibition'
+                : '/works'
+            }
             onClick={createSmoothLink(
-              type === 'exhibition' ? (alternateGalleryLink || '/about-exhibition#exhibition') : '/#works',
+              type === 'exhibition'
+                ? alternateGalleryLink || '/about-exhibition#exhibition'
+                : '/works',
             )}
             className="group inline-flex items-center px-4 py-2 text-hot-pink hover:text-white-rose hover:scale-105 active:scale-95 transition-all duration-300 ease-out text-sm font-light tracking-wider uppercase whitespace-nowrap"
           >
@@ -111,6 +117,7 @@ const MasonryGallery = ({
                   height={image.height || 400}
                   className="w-full h-auto object-cover"
                   sizes="(max-width: 768px) 50vw, 33vw"
+                  priority={index < 4}
                 />
               </div>
             </motion.div>

--- a/src/features/gallery/components/SwiperGallery.tsx
+++ b/src/features/gallery/components/SwiperGallery.tsx
@@ -23,24 +23,16 @@ const SwiperGallery = ({ images, title, galleryType }: GalleryProps) => {
   const [isClient, setIsClient] = useState(false)
   const swiperRef = useRef<any>(null)
   
-  // Dynamic alternate links - lightweight using only viewedGalleries  
-  const [staticAlternateLink, setStaticAlternateLink] = useState(
+  // Static alternate links - same as exhibition gallery
+  const staticAlternateLink = 
     galleryType === 'exhibition' 
       ? '/about-exhibition#exhibition'
       : galleryType === 'human' 
         ? '/gallery/non-human' 
         : '/gallery/human'
-  )
 
-  // Only track and update for human/non-human galleries
-  const shouldTrackProgress = galleryType === 'human' || galleryType === 'non-human'
-  const { hasViewedBothMainGalleries } = useGalleryTracking(galleryType)
-
-  useEffect(() => {
-    if (shouldTrackProgress && hasViewedBothMainGalleries()) {
-      setStaticAlternateLink('/socialbook')
-    }
-  }, [shouldTrackProgress, hasViewedBothMainGalleries])
+  // Track gallery viewing for analytics (no dynamic navigation changes)
+  useGalleryTracking(galleryType)
 
   // Ensure client-side rendering
   useEffect(() => {

--- a/src/features/gallery/services/galleryData.ts
+++ b/src/features/gallery/services/galleryData.ts
@@ -217,13 +217,22 @@ const nonHumanImages: GalleryImage[] = [
   },
 ]
 
-// Main function to get gallery images
+// Individual functions for each gallery type
+export const getHumanImages = async (): Promise<GalleryImage[]> => {
+  return humanImages
+}
+
+export const getNonHumanImages = async (): Promise<GalleryImage[]> => {
+  return nonHumanImages
+}
+
+// Legacy function for backward compatibility
 export const getGalleryImages = async (type: 'human' | 'non-human'): Promise<GalleryImage[]> => {
   switch (type) {
     case 'human':
-      return humanImages
+      return getHumanImages()
     case 'non-human':
-      return nonHumanImages
+      return getNonHumanImages()
     default:
       return []
   }

--- a/src/features/social-book/flipbook/components/flipbook-blur.css
+++ b/src/features/social-book/flipbook/components/flipbook-blur.css
@@ -250,22 +250,32 @@
   width: 100%;
   height: 100%;
   pointer-events: none;
-  background: linear-gradient(
-    90deg,
-    transparent 0%,
-    rgba(0, 0, 0, 0.05) 50%,
-    transparent 100%
-  );
+  background: linear-gradient(90deg, transparent 0%, rgba(0, 0, 0, 0.05) 50%, transparent 100%);
   opacity: 0;
   animation: shadowSweep 0.9s cubic-bezier(0.4, 0, 0.2, 1) forwards;
 }
 
 @keyframes shadowSweep {
-  0% { opacity: 0; transform: translateX(-100%); }
-  30% { opacity: 0.5; transform: translateX(-30%); }
-  50% { opacity: 0.8; transform: translateX(0%); }
-  70% { opacity: 0.5; transform: translateX(30%); }
-  100% { opacity: 0; transform: translateX(100%); }
+  0% {
+    opacity: 0;
+    transform: translateX(-100%);
+  }
+  30% {
+    opacity: 0.5;
+    transform: translateX(-30%);
+  }
+  50% {
+    opacity: 0.8;
+    transform: translateX(0%);
+  }
+  70% {
+    opacity: 0.5;
+    transform: translateX(30%);
+  }
+  100% {
+    opacity: 0;
+    transform: translateX(100%);
+  }
 }
 
 /* Navigation buttons */
@@ -324,28 +334,28 @@
   .flipbook-container {
     height: calc(100% - 100px); /* More space for bottom navigation */
   }
-  
+
   .flipbook {
     width: 100%;
     max-width: 100%;
     padding: 0 5px;
   }
-  
+
   .spread {
     aspect-ratio: unset;
     width: 100%;
   }
-  
+
   .page {
     width: 50%;
   }
-  
+
   /* Cover images on mobile should scale properly */
   .page-cover-image {
     object-fit: contain !important;
     object-position: center !important;
   }
-  
+
   /* Move navigation buttons to bottom */
   .nav-button {
     position: fixed;
@@ -356,17 +366,17 @@
     background: rgba(0, 0, 0, 0.7);
     border-radius: 50%;
   }
-  
+
   .nav-button-prev {
     left: 5px;
     transform: none;
   }
-  
+
   .nav-button-next {
     right: 5px;
     transform: none;
   }
-  
+
   .page-indicator {
     bottom: 75px;
     font-size: 14px;
@@ -415,7 +425,7 @@
   width: 20px;
   height: 20px;
   border-radius: 50%;
-  background: #8B5CF6;
+  background: #8b5cf6;
   cursor: pointer;
   transition: all 0.2s ease;
   box-shadow: 0 2px 6px rgba(139, 92, 246, 0.4);
@@ -430,7 +440,7 @@
   width: 20px;
   height: 20px;
   border-radius: 50%;
-  background: #8B5CF6;
+  background: #8b5cf6;
   cursor: pointer;
   border: none;
   transition: all 0.2s ease;
@@ -477,295 +487,105 @@
   .desktop-only {
     display: none;
   }
-  
+
   .mobile-only {
     display: block;
   }
-  
+
   .page-slider-container {
     bottom: 75px;
     min-width: 240px;
     padding: 0.75rem 1.25rem;
     border-radius: 22px;
   }
-  
+
   .page-slider {
     height: 8px;
     margin-bottom: 0.5rem;
   }
-  
+
   .page-slider::-webkit-slider-thumb {
     width: 24px;
     height: 24px;
   }
-  
+
   .page-slider::-moz-range-thumb {
     width: 24px;
     height: 24px;
   }
-  
+
   .page-slider::-webkit-slider-track {
     height: 8px;
   }
-  
+
   .page-slider::-moz-range-track {
     height: 8px;
   }
-  
+
   .page-slider-labels {
     font-size: 14px;
   }
 }
 
-/* Safari-specific optimizations */
+/* Safari-specific optimizations - Minimal Set */
+/* We only apply essential fixes here. Logic matches standard browser behavior. */
+
 .safari-browser .flipbook-wrapper {
   -webkit-transform-style: preserve-3d;
-  transform-style: preserve-3d;
-  -webkit-backface-visibility: hidden;
-  backface-visibility: hidden;
 }
 
 .safari-browser .flipbook-container {
   -webkit-transform-style: preserve-3d;
-  transform-style: preserve-3d;
   -webkit-perspective: 2000px;
 }
 
 .safari-browser .flipbook {
   -webkit-transform-style: preserve-3d;
-  will-change: transform;
-  transform: translateZ(0);
-  -webkit-transform: translateZ(0);
 }
 
 .safari-browser .spread {
   -webkit-transform-style: preserve-3d;
-  -webkit-backface-visibility: hidden;
-  backface-visibility: hidden;
 }
 
-.safari-browser .page {
-  -webkit-backface-visibility: hidden;
-  backface-visibility: hidden;
-  transform: translateZ(0);
-  -webkit-transform: translateZ(0);
-}
-
-.safari-browser .page-left {
-  -webkit-transform-origin: right center;
-}
-
-.safari-browser .page-right {
-  -webkit-transform-origin: left center;
-}
-
-.safari-browser .page-image {
-  opacity: 0.999 !important; /* Safari opacity workaround for backface visibility */
-  transform: translateZ(0.1px) !important;
-  -webkit-transform: translateZ(0.1px) !important;
-  image-rendering: -webkit-optimize-contrast;
-  -webkit-backface-visibility: hidden !important;
-  backface-visibility: hidden !important;
-}
-
+/* 
+   ANTI-FLICKER FIX:
+   Lift the animation container slightly in Z-space.
+   This prevents z-fighting with the static pages below.
+*/
 .safari-browser .flipping-page-container {
-  z-index: 5 !important; /* Reduced z-index for Safari - force override */
-  -webkit-transform-style: preserve-3d !important;
-  transform-style: preserve-3d !important;
-  -webkit-transform-origin: left center;
-  transform-origin: left center;
-  -webkit-backface-visibility: hidden !important;
-  backface-visibility: hidden !important;
-  will-change: transform;
-  /* Additional Safari stability */
-  isolation: isolate;
-}
+  -webkit-transform-style: preserve-3d;
+  transform-style: preserve-3d;
+  z-index: 50; /* Match standard z-index */
 
-.safari-browser .flipping-page-container-back {
-  -webkit-transform-origin: right center;
-  transform-origin: right center;
+  /* The Fix: */
+  transform: translateZ(1px);
+  -webkit-transform: translateZ(1px);
 }
 
 .safari-browser .flipping-page {
-  -webkit-transform-style: preserve-3d !important;
-  -webkit-transform-origin: left center;
-  transform-origin: left center;
-  will-change: transform, opacity;
-  transform: translateZ(1px); /* Force Safari layering */
-  opacity: 0.999;
-  /* Critical for preventing flickering - override the global visible setting */
-  backface-visibility: hidden !important;
-  -webkit-backface-visibility: hidden !important;
-  /* Force proper layering in Safari */
-  isolation: isolate;
+  -webkit-transform-style: preserve-3d;
+  /* Ensure backface is visible so we can see the reversed image */
+  backface-visibility: visible !important;
+  -webkit-backface-visibility: visible !important;
 }
 
-.safari-browser .flipping-page-back {
-  -webkit-transform-origin: right center;
-  transform-origin: right center;
+/* CRITICAL FIX: Ensure the image ITSELF is visible when rotated */
+.safari-browser .flipping-page .page-image {
+  backface-visibility: visible !important;
+  -webkit-backface-visibility: visible !important;
 }
 
 .safari-browser .nav-button {
-  z-index: 3; /* Reduced z-index for Safari */
-  -webkit-transform: translateY(-50%);
   -webkit-backface-visibility: hidden;
   backface-visibility: hidden;
 }
 
 .safari-browser .page-indicator {
-  z-index: 10; /* Reduced z-index for Safari */
-  -webkit-transform: translateX(-50%);
   -webkit-backface-visibility: hidden;
   backface-visibility: hidden;
 }
 
 .safari-browser .page-slider-container {
-  z-index: 10; /* Reduced z-index for Safari */
-  -webkit-transform: translateX(-50%);
   -webkit-backface-visibility: hidden;
   backface-visibility: hidden;
-}
-
-/* Safari animation timing adjustments */
-.safari-browser .flipping-page.flip-forward {
-  animation: flipForwardBlurSafari 0.9s cubic-bezier(0.4, 0, 0.2, 1) forwards;
-  /* Ensure visibility during entire animation */
-  backface-visibility: visible !important;
-  -webkit-backface-visibility: visible !important;
-}
-
-.safari-browser .flipping-page.flip-back {
-  animation: flipBackBlurSafari 0.9s cubic-bezier(0.4, 0, 0.2, 1) forwards;
-  /* Ensure visibility during entire animation */
-  backface-visibility: visible !important;
-  -webkit-backface-visibility: visible !important;
-}
-
-
-/* Safari-specific forward flip animation with adjusted timing */
-@keyframes flipForwardBlurSafari {
-  0% {
-    transform: rotateY(0deg) translateZ(1px);
-    filter: blur(0px) drop-shadow(2px 0 5px rgba(0, 0, 0, 0.2));
-    opacity: 1;
-    visibility: visible;
-  }
-  15% {
-    transform: rotateY(-30deg) translateZ(1px);
-    filter: blur(0.2px) drop-shadow(3px 0 8px rgba(0, 0, 0, 0.25));
-    opacity: 1;
-    visibility: visible;
-  }
-  30% {
-    transform: rotateY(-60deg) translateZ(1px);
-    filter: blur(0.5px) drop-shadow(4px 0 10px rgba(0, 0, 0, 0.3));
-    opacity: 1;
-    visibility: visible;
-  }
-  40% {
-    transform: rotateY(-80deg) translateZ(1px);
-    filter: blur(2px) drop-shadow(5px 0 12px rgba(0, 0, 0, 0.35));
-    opacity: 1;
-    visibility: visible;
-  }
-  45% {
-    transform: rotateY(-90deg) translateZ(1px);
-    filter: blur(3px) drop-shadow(6px 0 15px rgba(0, 0, 0, 0.4));
-    opacity: 1; /* Keep visible at 90 degrees */
-    visibility: visible;
-  }
-  50% {
-    transform: rotateY(-100deg) translateZ(1px);
-    filter: blur(3px) drop-shadow(6px 0 15px rgba(0, 0, 0, 0.4));
-    opacity: 1;
-    visibility: visible;
-  }
-  60% {
-    transform: rotateY(-120deg) translateZ(1px);
-    filter: blur(2px) drop-shadow(5px 0 12px rgba(0, 0, 0, 0.35));
-    opacity: 1;
-    visibility: visible;
-  }
-  70% {
-    transform: rotateY(-140deg) translateZ(1px);
-    filter: blur(0.5px) drop-shadow(4px 0 10px rgba(0, 0, 0, 0.3));
-    opacity: 1;
-    visibility: visible;
-  }
-  85% {
-    transform: rotateY(-160deg) translateZ(1px);
-    filter: blur(0.2px) drop-shadow(3px 0 8px rgba(0, 0, 0, 0.25));
-    opacity: 1;
-    visibility: visible;
-  }
-  100% {
-    transform: rotateY(-180deg) translateZ(1px);
-    filter: blur(0px) drop-shadow(2px 0 5px rgba(0, 0, 0, 0.2));
-    opacity: 1;
-    visibility: visible;
-  }
-}
-
-/* Safari-specific back flip animation with adjusted timing */
-@keyframes flipBackBlurSafari {
-  0% {
-    transform: rotateY(0deg) translateZ(1px);
-    filter: blur(0px) drop-shadow(-2px 0 5px rgba(0, 0, 0, 0.2));
-    opacity: 1;
-    visibility: visible;
-  }
-  15% {
-    transform: rotateY(30deg) translateZ(1px);
-    filter: blur(0.2px) drop-shadow(-3px 0 8px rgba(0, 0, 0, 0.25));
-    opacity: 1;
-    visibility: visible;
-  }
-  30% {
-    transform: rotateY(60deg) translateZ(1px);
-    filter: blur(0.5px) drop-shadow(-4px 0 10px rgba(0, 0, 0, 0.3));
-    opacity: 1;
-    visibility: visible;
-  }
-  40% {
-    transform: rotateY(80deg) translateZ(1px);
-    filter: blur(2px) drop-shadow(-5px 0 12px rgba(0, 0, 0, 0.35));
-    opacity: 1;
-    visibility: visible;
-  }
-  45% {
-    transform: rotateY(90deg) translateZ(1px);
-    filter: blur(3px) drop-shadow(-6px 0 15px rgba(0, 0, 0, 0.4));
-    opacity: 1; /* Keep visible at 90 degrees */
-    visibility: visible;
-  }
-  50% {
-    transform: rotateY(100deg) translateZ(1px);
-    filter: blur(3px) drop-shadow(-6px 0 15px rgba(0, 0, 0, 0.4));
-    opacity: 1;
-    visibility: visible;
-  }
-  60% {
-    transform: rotateY(120deg) translateZ(1px);
-    filter: blur(2px) drop-shadow(-5px 0 12px rgba(0, 0, 0, 0.35));
-    opacity: 1;
-    visibility: visible;
-  }
-  70% {
-    transform: rotateY(140deg) translateZ(1px);
-    filter: blur(0.5px) drop-shadow(-4px 0 10px rgba(0, 0, 0, 0.3));
-    opacity: 1;
-    visibility: visible;
-  }
-  85% {
-    transform: rotateY(160deg) translateZ(1px);
-    filter: blur(0.2px) drop-shadow(-3px 0 8px rgba(0, 0, 0, 0.25));
-    opacity: 1;
-    visibility: visible;
-  }
-  100% {
-    transform: rotateY(180deg) translateZ(1px);
-    filter: blur(0px) drop-shadow(-2px 0 5px rgba(0, 0, 0, 0.2));
-    opacity: 1;
-    visibility: visible;
-  }
 }

--- a/src/shared/ui/ImageWithLoader.tsx
+++ b/src/shared/ui/ImageWithLoader.tsx
@@ -3,7 +3,12 @@ import Image from 'next/image'
 import { GalleryImageProps } from '@/types/gallery'
 import LoadingSpinner from './LoadingSpinner'
 
-const ImageWithLoader = ({ image, priority = false, onLoad }: GalleryImageProps) => {
+const ImageWithLoader = ({
+  image,
+  priority = false,
+  onLoad,
+  sizes = '100vw',
+}: GalleryImageProps) => {
   const [isLoading, setIsLoading] = useState(true)
 
   return (
@@ -11,15 +16,18 @@ const ImageWithLoader = ({ image, priority = false, onLoad }: GalleryImageProps)
       {isLoading && (
         <div className="absolute inset-0 bg-grainy">
           {/* Shimmer effect */}
-          <div className="absolute inset-0 bg-gradient-to-r from-transparent via-hot-pink/10 to-transparent animate-[shimmer_1.5s_ease-in-out_infinite] motion-reduce:animate-none" 
-               style={{
-                 background: 'linear-gradient(90deg, transparent 0%, rgba(255, 105, 180, 0.1) 50%, transparent 100%)',
-                 animation: 'shimmer 1.5s ease-in-out infinite'
-               }} />
-          
+          <div
+            className="absolute inset-0 bg-gradient-to-r from-transparent via-hot-pink/10 to-transparent animate-[shimmer_1.5s_ease-in-out_infinite] motion-reduce:animate-none"
+            style={{
+              background:
+                'linear-gradient(90deg, transparent 0%, rgba(255, 105, 180, 0.1) 50%, transparent 100%)',
+              animation: 'shimmer 1.5s ease-in-out infinite',
+            }}
+          />
+
           {/* Skeleton placeholder */}
           <div className="absolute inset-4 bg-neutral-800/30 rounded-sm animate-pulse motion-reduce:animate-none" />
-          
+
           {/* Loading spinner */}
           <div className="absolute inset-0 flex items-center justify-center">
             <LoadingSpinner size="sm" showText={false} />
@@ -34,17 +42,22 @@ const ImageWithLoader = ({ image, priority = false, onLoad }: GalleryImageProps)
           isLoading ? 'opacity-0' : 'opacity-100'
         }`}
         priority={priority}
+        sizes={sizes}
         onLoad={() => {
           setIsLoading(false)
           onLoad?.()
         }}
       />
-      
+
       {/* Custom shimmer keyframes */}
       <style jsx>{`
         @keyframes shimmer {
-          0% { transform: translateX(-100%); }
-          100% { transform: translateX(100%); }
+          0% {
+            transform: translateX(-100%);
+          }
+          100% {
+            transform: translateX(100%);
+          }
         }
       `}</style>
     </div>

--- a/src/types/gallery.ts
+++ b/src/types/gallery.ts
@@ -16,6 +16,7 @@ export interface GalleryImageProps {
   image: GalleryImage
   priority?: boolean
   onLoad?: () => void
+  sizes?: string
 }
 
 export interface MasonryGalleryProps {


### PR DESCRIPTION
  Summary

  - Simplify gallery navigation by removing dynamic socialbook progression
  - Create dedicated /works page with Works + Social Book sections
  - Split gallery data services into individual functions
  - Unify human/non-human galleries to work like exhibition gallery

  Changes Made

  Navigation Simplification

  - Removed dynamic tracking logic that changed navigation based on viewing progress
  - All human/non-human galleries now use static navigation links
  - Masonry gallery "Go Back" now routes to /works instead of /#works

  New /works Page

  - Created /app/works/page.tsx with Header + Works + Social Book + Footer
  - Bypasses cinematic hero for smooth navigation from masonry galleries
  - Provides same content as home page but without scroll interference

  Gallery Data Refactoring

  - Split getGalleryImages() into getHumanImages() and getNonHumanImages()
  - Updated gallery pages to use dedicated functions
  - Maintained backward compatibility with legacy function

  Code Cleanup

  - Removed shouldTrackProgress and hasViewedBothMainGalleries logic
  - Eliminated conditional socialbook link rendering
  - Simplified navigation to consistent "Go Back ↗" pattern

  Test plan

  - Human gallery navigation works correctly
  - Non-human gallery navigation works correctly
  - Masonry "Go Back" routes to /works page
  - Exhibition gallery continues to route to /about-exhibition#exhibition
  - Gallery tracking still works for analytics
  - New /works page displays Works and Social Book sections